### PR TITLE
Remove a Game

### DIFF
--- a/public/javascripts/gameRoom.js
+++ b/public/javascripts/gameRoom.js
@@ -74,7 +74,7 @@ $(document).ready(function () {
     gameIO.on('player left', function (data) {
         console.log(data.msg);
         if (data.redirect) {
-            setTimeout(function () { window.location.href = data.url }, 3000);
+            setTimeout(function () { window.location.href = data.url; }, 3000);
         }
     });
 });

--- a/routes/gameRoute.js
+++ b/routes/gameRoute.js
@@ -49,8 +49,6 @@ var gameRouter = function (io) {
         */
         socket.on('load', function (data) {
 
-            console.log("gameroom id: " + data.roomID);
-
             var roomID = data.roomID;
 
             //if room doesn't exist create and add it to list
@@ -62,8 +60,6 @@ var gameRouter = function (io) {
                 setUpUserSocket(socket, data);
 
                 addFirstUser(data);
-
-               //console.log(gamesList);
 
                 //TODO emit to user waiting for other player
                 socket.emit('waiting', { waiting: "waiting for player 2 to join" });

--- a/routes/gameRoute.js
+++ b/routes/gameRoute.js
@@ -78,7 +78,7 @@ var gameRouter = function (io) {
                 setUpUserSocket(socket, data);
 
                 addSecondUser(socket);
-                console.log(gamesList);
+                //console.log(gamesList);
 
                 //emit user 2 has joined game
                 socket.emit('waiting', { waiting: "player two has joined" });
@@ -90,6 +90,7 @@ var gameRouter = function (io) {
                 socket.emit('redirect', { redirect: true, url: "/lobby" });
             }
 
+            console.log(gamesList);
         });
 
         /**
@@ -106,6 +107,14 @@ var gameRouter = function (io) {
         socket.on('disconnect', function() {
             var message = "player has left the game";
 
+            var aCurrentUser = typeof(gamesList[socket.room]);
+            console.log(aCurrentUser);
+            
+            if (aCurrentUser !== 'undefined') {
+                gamesList.splice(socket.room, 1);
+            }
+
+            console.log(gamesList);
             console.log(message);
             io.to(socket.room).emit('player left', { msg: message, redirect: true, url: "/lobby" });
         });


### PR DESCRIPTION
a Game is now removed from the gameslist upon players leaving room (only current players not players who couldn't get in cause of capacity).

Players are able to no go back into a room that has been emptied and start a new game.

TODO test if all functionality still works on re-created rooms